### PR TITLE
Include InMemoryFeatureFlagDataStoreOverride

### DIFF
--- a/core/src/commonMain/kotlin/energy/octopus/monarch/InMemoryFeatureFlagDataStoreOverride.kt
+++ b/core/src/commonMain/kotlin/energy/octopus/monarch/InMemoryFeatureFlagDataStoreOverride.kt
@@ -1,0 +1,105 @@
+package energy.octopus.monarch
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.*
+
+@ExperimentalCoroutinesApi
+public class InMemoryFeatureFlagDataStoreOverride(
+    private val delegate: ObservableFeatureFlagDataStore,
+    initialOverrides: Map<String, Any> = emptyMap()
+) : ObservableFeatureFlagDataStore {
+
+    private val cache: MutableStateFlow<Map<String, Any>> = MutableStateFlow(initialOverrides)
+
+    public override fun getBoolean(key: String): Boolean? {
+        return cache.getCachedValue<Boolean>(key) ?: delegate.getBoolean(key)
+    }
+
+    public override fun getString(key: String): String? {
+        return cache.getCachedValue<String>(key) ?: delegate.getString(key)
+    }
+
+    public override fun getDouble(key: String): Double? {
+        return cache.getCachedValue<Double>(key) ?: delegate.getDouble(key)
+    }
+
+    public override fun getLong(key: String): Long? {
+        return cache.getCachedValue<Long>(key) ?: delegate.getLong(key)
+    }
+
+    public override fun getByteArray(key: String): ByteArray? {
+        return cache.getCachedValue<ByteArray>(key) ?: delegate.getByteArray(key)
+    }
+
+    public override fun observeBoolean(key: String): Flow<Boolean?> {
+        return cache.observeCachedValue<Boolean>(key).flatMapLatest { cachedValue ->
+            when (cachedValue) {
+                null -> delegate.observeBoolean(key)
+                else -> flowOf(cachedValue)
+            }
+        }
+    }
+
+    public override fun observeString(key: String): Flow<String?> {
+        return cache.observeCachedValue<String>(key).flatMapLatest { cachedValue ->
+            when (cachedValue) {
+                null -> delegate.observeString(key)
+                else -> flowOf(cachedValue)
+            }
+        }
+    }
+
+    public override fun observeDouble(key: String): Flow<Double?> {
+        return cache.observeCachedValue<Double>(key).flatMapLatest { cachedValue ->
+            when (cachedValue) {
+                null -> delegate.observeDouble(key)
+                else -> flowOf(cachedValue)
+            }
+        }
+    }
+
+    public override fun observeLong(key: String): Flow<Long?> {
+        return cache.observeCachedValue<Long>(key).flatMapLatest { cachedValue ->
+            when (cachedValue) {
+                null -> delegate.observeLong(key)
+                else -> flowOf(cachedValue)
+            }
+        }
+    }
+
+    public override fun observeByteArray(key: String): Flow<ByteArray?> {
+        return cache.observeCachedValue<ByteArray>(key).flatMapLatest { cachedValue ->
+            when (cachedValue) {
+                null -> delegate.observeByteArray(key)
+                else -> flowOf(cachedValue)
+            }
+        }
+    }
+
+    public fun setBoolean(key: String, value: Boolean) {
+        cache.update { map -> map + Pair(key, value) }
+    }
+
+    public fun setString(key: String, value: String) {
+        cache.update { map -> map + Pair(key, value) }
+    }
+
+    public fun setDouble(key: String, value: Double) {
+        cache.update { map -> map + Pair(key, value) }
+    }
+
+    public fun setLong(key: String, value: Long) {
+        cache.update { map -> map + Pair(key, value) }
+    }
+    public fun setByteArray(key: String, value: ByteArray) {
+        cache.update { map -> map + Pair(key, value) }
+    }
+}
+
+private inline fun <reified T : Any> StateFlow<Map<String, Any>>.getCachedValue(key: String): T? {
+    return value[key] as? T
+}
+
+private inline fun <reified T : Any> StateFlow<Map<String, Any>>.observeCachedValue(key: String): Flow<T?> {
+    return map { map -> map[key] as? T }.distinctUntilChanged()
+}

--- a/core/src/commonTest/kotlin/energy/octopus/monarch/InMemoryFeatureFlagDataStoreOverrideTest.kt
+++ b/core/src/commonTest/kotlin/energy/octopus/monarch/InMemoryFeatureFlagDataStoreOverrideTest.kt
@@ -1,0 +1,163 @@
+package energy.octopus.monarch
+
+import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class InMemoryFeatureFlagDataStoreOverrideTest {
+
+    @Test fun store_cache_overrides_delegate_synchronous() {
+        listOf<Triple<Any, Any, InMemoryFeatureFlagDataStoreOverride.(String) -> Any?>>(
+            Triple(true, false) { getBoolean(it) },
+            Triple("correct", "incorrect") { getString(it) },
+            Triple(1.5, 3.0) { getDouble(it) },
+            Triple(1L, 2L) { getLong(it) },
+            Triple(byteArrayOf(0b1), byteArrayOf(0b0)) { getByteArray(it) }
+        ).forEach { (overrideValue, delegateValue, produceFn) ->
+            testCacheOverridesDelegateSynchronousParameterized(overrideValue, delegateValue, produceFn)
+        }
+    }
+
+    private fun testCacheOverridesDelegateSynchronousParameterized(
+        overrideValue: Any,
+        delegateValue: Any,
+        produceValue: InMemoryFeatureFlagDataStoreOverride.(String) -> Any?
+    ) {
+        val key = "foo"
+        val delegate = FakeFeatureFlagDataStore().apply { setValue(key, delegateValue) }
+        val storeOverride = storeOverride(
+            initialOverrides = mapOf(key to overrideValue),
+            delegate = delegate,
+        )
+
+        assertEquals(
+            expected = overrideValue,
+            actual = storeOverride.produceValue(key),
+        )
+    }
+
+    @Test fun store_cache_falls_back_to_delegate_synchronous() {
+        listOf<Pair<Any, InMemoryFeatureFlagDataStoreOverride.(String) -> Any?>>(
+            Pair(false) { getBoolean(it) },
+            Pair("correct") { getString(it) },
+            Pair(3.0) { getDouble(it) },
+            Pair(2L) { getLong(it) },
+            Pair(byteArrayOf(0b0)) { getByteArray(it) }
+        ).forEach { (delegateValue, produceFn) ->
+            testCacheFallsBackToDelegateSynchronousParameterized(delegateValue, produceFn)
+        }
+    }
+
+    private fun testCacheFallsBackToDelegateSynchronousParameterized(
+        delegateValue: Any,
+        produceValue: InMemoryFeatureFlagDataStoreOverride.(String) -> Any?
+    ) {
+        val key = "foo"
+        val delegate = FakeFeatureFlagDataStore().apply { setValue(key, delegateValue) }
+        val storeOverride = storeOverride(delegate = delegate)
+
+        assertEquals(
+            expected = delegateValue,
+            actual = storeOverride.produceValue(key),
+        )
+    }
+
+    @Test fun store_cache_overrides_delegate_flow() {
+        listOf<Triple<Any, Any, InMemoryFeatureFlagDataStoreOverride.(String) -> Flow<*>>>(
+            Triple(true, false) { observeBoolean(it) },
+            Triple("correct", "incorrect") { observeString(it) },
+            Triple(1.5, 3.0) { observeDouble(it) },
+            Triple(1L, 2L) { observeLong(it) },
+            Triple(byteArrayOf(0b1), byteArrayOf(0b0)) { observeByteArray(it) }
+        ).forEach { (overrideValue, delegateValue, produceFn) ->
+            storeCacheOverridesDelegateFlowParameterized(overrideValue, delegateValue, produceFn)
+        }
+    }
+
+    private fun storeCacheOverridesDelegateFlowParameterized(
+        overrideValue: Any,
+        delegateValue: Any,
+        produceFlow: InMemoryFeatureFlagDataStoreOverride.(String) -> Flow<*>
+    ) = runBlocking {
+        val key = "foo"
+        val delegate = FakeFeatureFlagDataStore().apply { setValue(key, delegateValue) }
+        val storeOverride = storeOverride(
+            initialOverrides = mapOf(key to overrideValue),
+            delegate = delegate,
+        )
+
+        storeOverride.produceFlow(key).test {
+            assertEquals(
+                expected = overrideValue,
+                actual = awaitItem(),
+            )
+        }
+    }
+
+    @Test fun store_cache_falls_back_to_delegate_flow() {
+        listOf<Pair<Any, InMemoryFeatureFlagDataStoreOverride.(String) -> Flow<*>>>(
+            Pair(false) { observeBoolean(it) },
+            Pair("correct") { observeString(it) },
+            Pair(3.0) { observeDouble(it) },
+            Pair(2L) { observeLong(it) },
+            Pair(byteArrayOf(0b0)) { observeByteArray(it) }
+        ).forEach { (delegateValue, produceFn) ->
+            storeCacheFallsBackToDelegateFlowParameterized(delegateValue, produceFn)
+        }
+    }
+
+    private fun storeCacheFallsBackToDelegateFlowParameterized(
+        delegateValue: Any,
+        produceFlow: InMemoryFeatureFlagDataStoreOverride.(String) -> Flow<*>
+    ) = runBlocking {
+        val key = "foo"
+        val delegate = FakeFeatureFlagDataStore().apply { setValue(key, delegateValue) }
+        val storeOverride = storeOverride(delegate = delegate)
+
+        storeOverride.produceFlow(key).test {
+            assertEquals(
+                expected = delegateValue,
+                actual = awaitItem(),
+            )
+        }
+    }
+
+    @Test fun writing_to_store_cache_emits_new_value_in_active_flows() {
+        listOf<Triple<Any, InMemoryFeatureFlagDataStoreOverride.(String) -> Unit, InMemoryFeatureFlagDataStoreOverride.(String) -> Flow<*>>>(
+            Triple(true, { setBoolean(it, false) }) { observeBoolean(it) },
+            Triple("correct", { setString(it, "also correct") }) { observeString(it) },
+            Triple(1.5, { setDouble(it, 3.0) }) { observeDouble(it) },
+            Triple(1L, { setLong(it, 3L) }) { observeLong(it) },
+            Triple(byteArrayOf(0b1), { setByteArray(it, byteArrayOf(0b0)) }) { observeByteArray(it) }
+        ).forEach { (initialValue, newValue, produceFn) ->
+            writingToStoreCacheEmitsNewValueParameterized(initialValue, newValue, produceFn)
+        }
+    }
+
+    private fun writingToStoreCacheEmitsNewValueParameterized(
+        initialValue: Any,
+        setNewValue: InMemoryFeatureFlagDataStoreOverride.(String) -> Unit,
+        produceFlow: InMemoryFeatureFlagDataStoreOverride.(String) -> Flow<*>
+    ) = runBlocking {
+        val key = "foo"
+        val storeOverride = storeOverride(initialOverrides = mapOf(key to initialValue))
+        storeOverride.produceFlow(key).test {
+            assertEquals(
+                expected = initialValue,
+                actual = awaitItem(),
+            )
+            storeOverride.setNewValue(key)
+            assertNotEquals(illegal = initialValue, actual = awaitItem())
+        }
+    }
+
+    private fun storeOverride(
+        initialOverrides: Map<String, Any> = emptyMap(),
+        delegate: ObservableFeatureFlagDataStore = FakeFeatureFlagDataStore()
+    ) = InMemoryFeatureFlagDataStoreOverride(delegate, initialOverrides)
+}


### PR DESCRIPTION
This class will be useful for locally overriding remote feature
flags, particularly during development cycles.

Closes #18
