### PR TITLE
Rename *valueFor to *valueOf

### DIFF
--- a/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/FeatureFlagManager.kt
+++ b/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/FeatureFlagManager.kt
@@ -8,5 +8,5 @@ public interface FeatureFlagManager {
     /**
      * Get the current value of [flag].
      */
-    public fun <T : Any> currentValueFor(flag: FeatureFlag<T>): T
+    public fun <T : Any> currentValueOf(flag: FeatureFlag<T>): T
 }

--- a/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/FeatureFlagManagerMixin.kt
+++ b/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/FeatureFlagManagerMixin.kt
@@ -2,7 +2,7 @@ package io.github.kevincianfarini.monarch
 
 /**
  * A supplement to [MixinFeatureFlagManager] that allows extension via
- * [FeatureFlagManagerMixin.currentValueForOrNull]. Implementations of this interface
+ * [FeatureFlagManagerMixin.currentValueOfOrNull]. Implementations of this interface
  * can opt to handle 1 or more [FeatureFlag] types. For example, if we want to add a mixin that
  * supports JSON, we could do so with the following code.
  *
@@ -27,7 +27,7 @@ public interface FeatureFlagManagerMixin {
      * Get the current value for [flag] as [T] from [store]. This function will return null if this
      * [FeatureFlagManagerMixin] does not handle [flag].
      */
-    public fun <T : Any> currentValueForOrNull(
+    public fun <T : Any> currentValueOfOrNull(
         flag: FeatureFlag<T>,
         store: FeatureFlagDataStore,
     ): T?

--- a/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/MixinFeatureFlagManager.kt
+++ b/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/MixinFeatureFlagManager.kt
@@ -17,7 +17,7 @@ public class MixinFeatureFlagManager(
 ) : FeatureFlagManager {
 
     @Suppress("UNCHECKED_CAST")
-    public override fun <T : Any> currentValueFor(flag: FeatureFlag<T>): T = when (flag) {
+    public override fun <T : Any> currentValueOf(flag: FeatureFlag<T>): T = when (flag) {
         is BooleanFeatureFlag -> {
             val value = store.getBoolean(flag.key)
             (value ?: flag.default) as T
@@ -39,7 +39,7 @@ public class MixinFeatureFlagManager(
             (value ?: flag.default) as T
         }
         else -> mixins.firstNotNullOfOrNull { delegate ->
-            delegate.currentValueForOrNull(flag, store)
+            delegate.currentValueOfOrNull(flag, store)
         } ?: throw IllegalArgumentException("$flag is not a recognized feature flag.")
     }
 }

--- a/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/ObservableFeatureFlagManager.kt
+++ b/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/ObservableFeatureFlagManager.kt
@@ -7,5 +7,5 @@ public interface ObservableFeatureFlagManager : FeatureFlagManager {
     /**
      * Emits value changes of [flag].
      */
-    public fun <T : Any> valuesFor(flag: FeatureFlag<T>): Flow<T>
+    public fun <T : Any> valuesOf(flag: FeatureFlag<T>): Flow<T>
 }

--- a/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/ObservableFeatureFlagManagerMixin.kt
+++ b/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/ObservableFeatureFlagManagerMixin.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.Flow
 
 /**
  * A supplement to [ObservableMixinFeatureFlagManager] that allows extension via
- * [ObservableFeatureFlagManagerMixin.valuesOrNull]. Implementations of this interface
+ * [ObservableFeatureFlagManagerMixin.valuesOfOrNull]. Implementations of this interface
  * can opt to handle 1 or more [FeatureFlag] types. For example, if we want to add a mixin that
  * supports JSON, we could do so with the following code.
  *
@@ -29,5 +29,5 @@ public interface ObservableFeatureFlagManagerMixin : FeatureFlagManagerMixin {
      * Observes values for [flag] as [Flow<T>] from [store]. This function will return null if this
      * [ObservableFeatureFlagManagerMixin] does not handle [flag].
      */
-    public fun <T : Any> valuesOrNull(flag: FeatureFlag<T>, store: ObservableFeatureFlagDataStore): Flow<T>?
+    public fun <T : Any> valuesOfOrNull(flag: FeatureFlag<T>, store: ObservableFeatureFlagDataStore): Flow<T>?
 }

--- a/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/ObservableMixinFeatureFlagManager.kt
+++ b/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/ObservableMixinFeatureFlagManager.kt
@@ -20,7 +20,7 @@ public class ObservableMixinFeatureFlagManager(
 ) : ObservableFeatureFlagManager, FeatureFlagManager by MixinFeatureFlagManager(store, mixins) {
 
     @Suppress("UNCHECKED_CAST")
-    public override fun <T : Any> valuesFor(flag: FeatureFlag<T>): Flow<T> = when (flag) {
+    public override fun <T : Any> valuesOf(flag: FeatureFlag<T>): Flow<T> = when (flag) {
         is BooleanFeatureFlag -> store.observeBoolean(flag.key).map { value ->
             (value ?: flag.default) as T
         }
@@ -37,7 +37,7 @@ public class ObservableMixinFeatureFlagManager(
             (value ?: flag.default) as T
         }
         else -> mixins.firstNotNullOfOrNull { delegate ->
-            delegate.valuesOrNull(flag, store)
+            delegate.valuesOfOrNull(flag, store)
         } ?: throw IllegalArgumentException("$flag is not a recognized feature flag.")
     }
 }

--- a/core/src/commonTest/kotlin/io/github/kevincianfarini/monarch/MixinFeatureFlagManagerTest.kt
+++ b/core/src/commonTest/kotlin/io/github/kevincianfarini/monarch/MixinFeatureFlagManagerTest.kt
@@ -8,34 +8,34 @@ class MixinFeatureFlagManagerTest {
         val store = InMemoryFeatureFlagDataStore().apply { setValue("foo", "bar") }
         assertEquals(
             expected = "bar",
-            actual = manager(store).currentValueFor(StringFeature),
+            actual = manager(store).currentValueOf(StringFeature),
         )
     }
 
     @Test fun `manager gets default string value`() = assertEquals(
         expected = "blah",
-        actual = manager().currentValueFor(StringFeature),
+        actual = manager().currentValueOf(StringFeature),
     )
 
     @Test fun `manager gets boolean value`() {
         val store = InMemoryFeatureFlagDataStore().apply { setValue("bool", true) }
-        assertTrue(manager(store).currentValueFor(BooleanFeature))
+        assertTrue(manager(store).currentValueOf(BooleanFeature))
     }
 
-    @Test fun `manager gets default boolean value`() = assertFalse(manager().currentValueFor(BooleanFeature))
+    @Test fun `manager gets default boolean value`() = assertFalse(manager().currentValueOf(BooleanFeature))
 
     @Test fun `manager gets double value`() {
         val store = InMemoryFeatureFlagDataStore().apply { setValue("double", 15.7) }
         assertEquals(
             expected = 15.7,
-            actual = manager(store).currentValueFor(DoubleFeature),
+            actual = manager(store).currentValueOf(DoubleFeature),
             absoluteTolerance = 0.05,
         )
     }
 
     @Test fun `manager gets default double value`() = assertEquals(
         expected = 1.5,
-        actual = manager().currentValueFor(DoubleFeature),
+        actual = manager().currentValueOf(DoubleFeature),
         absoluteTolerance = 0.05,
     )
 
@@ -43,33 +43,33 @@ class MixinFeatureFlagManagerTest {
         val store = InMemoryFeatureFlagDataStore().apply { setValue("long", 27L) }
         assertEquals(
             expected = 27L,
-            actual = manager(store).currentValueFor(LongFeature),
+            actual = manager(store).currentValueOf(LongFeature),
         )
     }
 
     @Test fun `manager gets default long value`() = assertEquals(
         expected = 1027L,
-        actual = manager().currentValueFor(LongFeature),
+        actual = manager().currentValueOf(LongFeature),
     )
 
     @Test fun `manager gets byte array value`() {
         val store = InMemoryFeatureFlagDataStore().apply { setValue("byte", byteArrayOf(0b11)) }
         assertContentEquals(
             expected = byteArrayOf(0b11),
-            actual = manager(store).currentValueFor(ByteArrayFeature),
+            actual = manager(store).currentValueOf(ByteArrayFeature),
         )
     }
 
     @Test fun `manager gets default byte array value`() = assertContentEquals(
         expected = byteArrayOf(0b1),
-        actual = manager().currentValueFor(ByteArrayFeature),
+        actual = manager().currentValueOf(ByteArrayFeature),
     )
 
     @Test fun `manager gets mixin value`() {
         val store = InMemoryFeatureFlagDataStore().apply { setValue("some_int", "1") }
         assertEquals(
             expected = 1,
-            actual = manager(store, listOf(ObservableIntDecodingMixin)).currentValueFor(IntFeatureFlag),
+            actual = manager(store, listOf(ObservableIntDecodingMixin)).currentValueOf(IntFeatureFlag),
         )
     }
 
@@ -81,7 +81,7 @@ class MixinFeatureFlagManagerTest {
         }
 
         assertFailsWith<IllegalArgumentException> {
-            manager().currentValueFor(someRandomFlag)
+            manager().currentValueOf(someRandomFlag)
         }
     }
 

--- a/core/src/commonTest/kotlin/io/github/kevincianfarini/monarch/ObservableMixinFeatureFlagManagerTest.kt
+++ b/core/src/commonTest/kotlin/io/github/kevincianfarini/monarch/ObservableMixinFeatureFlagManagerTest.kt
@@ -9,7 +9,7 @@ class ObservableMixinFeatureFlagManagerTest {
     @Test fun `manager gets string value`() {
         runBlocking {
             val store = InMemoryFeatureFlagDataStore().apply { setValue("foo", "bar") }
-            manager(store).valuesFor(StringFeature).test {
+            manager(store).valuesOf(StringFeature).test {
                 assertEquals("bar", awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
@@ -18,7 +18,7 @@ class ObservableMixinFeatureFlagManagerTest {
 
     @Test fun `manager gets default string value`() {
         runBlocking {
-            manager().valuesFor(StringFeature).test {
+            manager().valuesOf(StringFeature).test {
                 assertEquals("blah", awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
@@ -28,7 +28,7 @@ class ObservableMixinFeatureFlagManagerTest {
     @Test fun `manager gets boolean value`() {
         runBlocking {
             val store = InMemoryFeatureFlagDataStore().apply { setValue("bool", true) }
-            manager(store).valuesFor(BooleanFeature).test {
+            manager(store).valuesOf(BooleanFeature).test {
                 assertTrue(awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
@@ -37,7 +37,7 @@ class ObservableMixinFeatureFlagManagerTest {
 
     @Test fun `manager gets default boolean value`() {
         runBlocking {
-            manager().valuesFor(BooleanFeature).test {
+            manager().valuesOf(BooleanFeature).test {
                 assertFalse(awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
@@ -47,7 +47,7 @@ class ObservableMixinFeatureFlagManagerTest {
     @Test fun `manager gets double value`() {
         runBlocking {
             val store = InMemoryFeatureFlagDataStore().apply { setValue("double", 15.7) }
-            manager(store).valuesFor(DoubleFeature).test {
+            manager(store).valuesOf(DoubleFeature).test {
                 assertEquals(expected = 15.7, actual = awaitItem(), absoluteTolerance = 0.05)
                 cancelAndIgnoreRemainingEvents()
             }
@@ -56,7 +56,7 @@ class ObservableMixinFeatureFlagManagerTest {
 
     @Test fun `manager gets default double value`() {
         runBlocking {
-            manager().valuesFor(DoubleFeature).test {
+            manager().valuesOf(DoubleFeature).test {
                 assertEquals(expected = 1.5, actual = awaitItem(), absoluteTolerance = 0.05)
                 cancelAndIgnoreRemainingEvents()
             }
@@ -66,7 +66,7 @@ class ObservableMixinFeatureFlagManagerTest {
     @Test fun `manager gets long value`() {
         runBlocking {
             val store = InMemoryFeatureFlagDataStore().apply { setValue("long", 27L) }
-            manager(store).valuesFor(LongFeature).test {
+            manager(store).valuesOf(LongFeature).test {
                 assertEquals(expected = 27L, actual = awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
@@ -75,7 +75,7 @@ class ObservableMixinFeatureFlagManagerTest {
 
     @Test fun `manager gets default long value`() {
         runBlocking {
-            manager().valuesFor(LongFeature).test {
+            manager().valuesOf(LongFeature).test {
                 assertEquals(expected = 1027L, actual = awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
@@ -85,7 +85,7 @@ class ObservableMixinFeatureFlagManagerTest {
     @Test fun `manager gets byte array value`() {
         runBlocking {
             val store = InMemoryFeatureFlagDataStore().apply { setValue("byte", byteArrayOf(0b11)) }
-            manager(store).valuesFor(ByteArrayFeature).test {
+            manager(store).valuesOf(ByteArrayFeature).test {
                 assertContentEquals(expected = byteArrayOf(0b11), actual = awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
@@ -94,7 +94,7 @@ class ObservableMixinFeatureFlagManagerTest {
 
     @Test fun `manager gets default byte array value`() {
         runBlocking {
-            manager().valuesFor(ByteArrayFeature).test {
+            manager().valuesOf(ByteArrayFeature).test {
                 assertContentEquals(expected = byteArrayOf(0b1), actual = awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
@@ -104,7 +104,7 @@ class ObservableMixinFeatureFlagManagerTest {
     @Test fun `manager gets mixin value`() {
         runBlocking {
             val store = InMemoryFeatureFlagDataStore().apply { setValue("some_int", "1") }
-            manager(store, listOf(ObservableIntDecodingMixin)).valuesFor(IntFeatureFlag).test {
+            manager(store, listOf(ObservableIntDecodingMixin)).valuesOf(IntFeatureFlag).test {
                 assertEquals(expected = 1, actual = awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
@@ -120,7 +120,7 @@ class ObservableMixinFeatureFlagManagerTest {
             }
 
             assertFailsWith<IllegalArgumentException> {
-                manager().valuesFor(someRandomFlag)
+                manager().valuesOf(someRandomFlag)
             }
         }
     }

--- a/core/src/commonTest/kotlin/io/github/kevincianfarini/monarch/flags.kt
+++ b/core/src/commonTest/kotlin/io/github/kevincianfarini/monarch/flags.kt
@@ -18,7 +18,7 @@ object IntFeatureFlag : FeatureFlag<Int> {
 
 // FeatureFlagManager mixin that handles IntFeatureFlags, returns Flow<IntOption>
 object ObservableIntDecodingMixin : ObservableFeatureFlagManagerMixin {
-    override fun <T : Any> valuesOrNull(
+    override fun <T : Any> valuesOfOrNull(
         flag: FeatureFlag<T>,
         store: ObservableFeatureFlagDataStore,
     ): Flow<T>? = when (flag) {
@@ -28,7 +28,7 @@ object ObservableIntDecodingMixin : ObservableFeatureFlagManagerMixin {
         else -> null
     }
 
-    override fun <T : Any> currentValueForOrNull(
+    override fun <T : Any> currentValueOfOrNull(
         flag: FeatureFlag<T>,
         store: FeatureFlagDataStore
     ): T? = when (flag) {

--- a/mixins/kotlinx-serialization-json/src/commonMain/kotlin/io/github/kevincianfarini/monarch/mixins/JsonFeatureFlagManagerMixin.kt
+++ b/mixins/kotlinx-serialization-json/src/commonMain/kotlin/io/github/kevincianfarini/monarch/mixins/JsonFeatureFlagManagerMixin.kt
@@ -9,7 +9,7 @@ public class JsonFeatureFlagManagerMixin(
     private val json: Json,
 ) : FeatureFlagManagerMixin {
 
-    public override fun <T : Any> currentValueForOrNull(
+    public override fun <T : Any> currentValueOfOrNull(
         flag: FeatureFlag<T>,
         store: FeatureFlagDataStore,
     ): T? = when (flag) {

--- a/mixins/kotlinx-serialization-json/src/commonMain/kotlin/io/github/kevincianfarini/monarch/mixins/ObservableJsonFeatureFlagManagerMixin.kt
+++ b/mixins/kotlinx-serialization-json/src/commonMain/kotlin/io/github/kevincianfarini/monarch/mixins/ObservableJsonFeatureFlagManagerMixin.kt
@@ -11,7 +11,7 @@ public class ObservableJsonFeatureFlagManagerMixin(
     private val json: Json,
 ) : ObservableFeatureFlagManagerMixin, FeatureFlagManagerMixin by JsonFeatureFlagManagerMixin(json) {
 
-    public override fun <T : Any> valuesOrNull(
+    public override fun <T : Any> valuesOfOrNull(
         flag: io.github.kevincianfarini.monarch.FeatureFlag<T>,
         store: ObservableFeatureFlagDataStore
     ): Flow<T>? = when (flag) {

--- a/mixins/kotlinx-serialization-json/src/commonTest/kotlin/io/github/kevincianfarini/monarch/mixins/JsonFeatureFlagManagerMixinTest.kt
+++ b/mixins/kotlinx-serialization-json/src/commonTest/kotlin/io/github/kevincianfarini/monarch/mixins/JsonFeatureFlagManagerMixinTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertNull
 class JsonFeatureFlagManagerMixinTest {
 
     @Test fun `returns null on unhandled feature flag`() = assertNull(
-        mixin().currentValueForOrNull(
+        mixin().currentValueOfOrNull(
             flag = NotJson,
             store = InMemoryFeatureFlagDataStore(),
         )
@@ -18,7 +18,7 @@ class JsonFeatureFlagManagerMixinTest {
 
     @Test fun `returns default on null value result`() = assertEquals(
         expected = SomeJsonFlag.default,
-        actual = mixin().currentValueForOrNull(
+        actual = mixin().currentValueOfOrNull(
             flag = SomeJsonFlag,
             store = InMemoryFeatureFlagDataStore(),
         )
@@ -33,7 +33,7 @@ class JsonFeatureFlagManagerMixinTest {
         }
         assertEquals(
             expected = Foo(2),
-            actual = mixin().currentValueForOrNull(
+            actual = mixin().currentValueOfOrNull(
                 flag = SomeJsonFlag,
                 store = store,
             )

--- a/test/src/commonMain/kotlin/io/github/kevincianfarini/monarch/InMemoryFeatureFlagManager.kt
+++ b/test/src/commonMain/kotlin/io/github/kevincianfarini/monarch/InMemoryFeatureFlagManager.kt
@@ -10,12 +10,12 @@ public class InMemoryFeatureFlagManager : ObservableFeatureFlagManager {
     private val store = MutableStateFlow<Map<String, Any>>(emptyMap())
 
     @Suppress("UNCHECKED_CAST")
-    public override fun <T : Any> currentValueFor(flag: FeatureFlag<T>): T {
+    public override fun <T : Any> currentValueOf(flag: FeatureFlag<T>): T {
         return (store.value[flag.key] ?: flag.default) as T
     }
 
     @Suppress("UNCHECKED_CAST")
-    public override fun <T : Any> valuesFor(flag: FeatureFlag<T>): Flow<T> {
+    public override fun <T : Any> valuesOf(flag: FeatureFlag<T>): Flow<T> {
         return store.map { map -> (map[flag.key] ?: flag.default) as T }
     }
 

--- a/test/src/commonTest/kotlin/io/github/kevincianfarini/monarch/FakeFeatureFlagManagerTest.kt
+++ b/test/src/commonTest/kotlin/io/github/kevincianfarini/monarch/FakeFeatureFlagManagerTest.kt
@@ -12,7 +12,7 @@ class FakeFeatureFlagManagerTest {
         runTest {
             assertEquals(
                 expected = SomeFlag.default,
-                actual = InMemoryFeatureFlagManager().currentValueFor(SomeFlag)
+                actual = InMemoryFeatureFlagManager().currentValueOf(SomeFlag)
             )
         }
     }
@@ -24,7 +24,7 @@ class FakeFeatureFlagManagerTest {
             }
             assertEquals(
                 expected = 1L,
-                actual = manager.currentValueFor(SomeFlag)
+                actual = manager.currentValueOf(SomeFlag)
             )
         }
     }
@@ -34,7 +34,7 @@ class FakeFeatureFlagManagerTest {
             assertEquals(
                 expected = SomeFlag.default,
                 actual = InMemoryFeatureFlagManager()
-                    .valuesFor(SomeFlag)
+                    .valuesOf(SomeFlag)
                     .first(),
             )
         }
@@ -43,7 +43,7 @@ class FakeFeatureFlagManagerTest {
     @Test fun `observing emits updates to flags`() {
         runTest {
             val manager = InMemoryFeatureFlagManager()
-            manager.valuesFor(SomeFlag).test {
+            manager.valuesOf(SomeFlag).test {
                 assertEquals(
                     expected = SomeFlag.default,
                     actual = awaitItem(),


### PR DESCRIPTION
This more closely aligns with other function naming conventions in
Kotlin like `listOf`, `listOfNotNull`, `mutableStateOf`, `flowOf`,
etc.

Closes #21
