### PR TITLE
Add default parameters to data store interfaces

### DIFF
--- a/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/FeatureFlagDataStore.kt
+++ b/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/FeatureFlagDataStore.kt
@@ -6,27 +6,27 @@ package io.github.kevincianfarini.monarch
 public interface FeatureFlagDataStore {
 
     /**
-     * Get the [Boolean] value associated with [key] if present. Otherwise, return null.
+     * Get the [Boolean] value associated with [key] if present. Otherwise, return [default].
      */
-    public fun getBoolean(key: String): Boolean?
+    public fun getBoolean(key: String, default: Boolean): Boolean
 
     /**
-     * Get the [String] value associated with [key] if present. Otherwise, return null.
+     * Get the [String] value associated with [key] if present. Otherwise, return [default].
      */
-    public fun getString(key: String): String?
+    public fun getString(key: String, default: String): String
 
     /**
-     * Get the [Double] value associated with [key] if present. Otherwise, return null.
+     * Get the [Double] value associated with [key] if present. Otherwise, return [default].
      */
-    public fun getDouble(key: String): Double?
+    public fun getDouble(key: String, default: Double): Double
 
     /**
-     * Get the [Long] value associated with [key] if present. Otherwise, return null.
+     * Get the [Long] value associated with [key] if present. Otherwise, return [default].
      */
-    public fun getLong(key: String): Long?
+    public fun getLong(key: String, default: Long): Long
 
     /**
-     * Get the [ByteArray] value associated with [key] if present. Otherwise, return null.
+     * Get the [ByteArray] value associated with [key] if present. Otherwise, return [default].
      */
-    public fun getByteArray(key: String): ByteArray?
+    public fun getByteArray(key: String, default: ByteArray): ByteArray
 }

--- a/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/InMemoryFeatureFlagDataStoreOverride.kt
+++ b/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/InMemoryFeatureFlagDataStoreOverride.kt
@@ -11,66 +11,66 @@ public class InMemoryFeatureFlagDataStoreOverride(
 
     private val cache: MutableStateFlow<Map<String, Any>> = MutableStateFlow(initialOverrides)
 
-    public override fun getBoolean(key: String): Boolean? {
-        return cache.getCachedValue<Boolean>(key) ?: delegate.getBoolean(key)
+    public override fun getBoolean(key: String, default: Boolean): Boolean {
+        return cache.getCachedValue<Boolean>(key) ?: delegate.getBoolean(key, default)
     }
 
-    public override fun getString(key: String): String? {
-        return cache.getCachedValue<String>(key) ?: delegate.getString(key)
+    public override fun getString(key: String, default: String): String {
+        return cache.getCachedValue<String>(key) ?: delegate.getString(key, default)
     }
 
-    public override fun getDouble(key: String): Double? {
-        return cache.getCachedValue<Double>(key) ?: delegate.getDouble(key)
+    public override fun getDouble(key: String, default: Double): Double {
+        return cache.getCachedValue<Double>(key) ?: delegate.getDouble(key, default)
     }
 
-    public override fun getLong(key: String): Long? {
-        return cache.getCachedValue<Long>(key) ?: delegate.getLong(key)
+    public override fun getLong(key: String, default: Long): Long {
+        return cache.getCachedValue<Long>(key) ?: delegate.getLong(key, default)
     }
 
-    public override fun getByteArray(key: String): ByteArray? {
-        return cache.getCachedValue<ByteArray>(key) ?: delegate.getByteArray(key)
+    public override fun getByteArray(key: String, default: ByteArray): ByteArray {
+        return cache.getCachedValue<ByteArray>(key) ?: delegate.getByteArray(key, default)
     }
 
-    public override fun observeBoolean(key: String): Flow<Boolean?> {
+    public override fun observeBoolean(key: String, default: Boolean): Flow<Boolean> {
         return cache.observeCachedValue<Boolean>(key).flatMapLatest { cachedValue ->
             when (cachedValue) {
-                null -> delegate.observeBoolean(key)
+                null -> delegate.observeBoolean(key, default)
                 else -> flowOf(cachedValue)
             }
         }
     }
 
-    public override fun observeString(key: String): Flow<String?> {
+    public override fun observeString(key: String, default: String): Flow<String> {
         return cache.observeCachedValue<String>(key).flatMapLatest { cachedValue ->
             when (cachedValue) {
-                null -> delegate.observeString(key)
+                null -> delegate.observeString(key, default)
                 else -> flowOf(cachedValue)
             }
         }
     }
 
-    public override fun observeDouble(key: String): Flow<Double?> {
+    public override fun observeDouble(key: String, default: Double): Flow<Double> {
         return cache.observeCachedValue<Double>(key).flatMapLatest { cachedValue ->
             when (cachedValue) {
-                null -> delegate.observeDouble(key)
+                null -> delegate.observeDouble(key, default)
                 else -> flowOf(cachedValue)
             }
         }
     }
 
-    public override fun observeLong(key: String): Flow<Long?> {
+    public override fun observeLong(key: String, default: Long): Flow<Long> {
         return cache.observeCachedValue<Long>(key).flatMapLatest { cachedValue ->
             when (cachedValue) {
-                null -> delegate.observeLong(key)
+                null -> delegate.observeLong(key, default)
                 else -> flowOf(cachedValue)
             }
         }
     }
 
-    public override fun observeByteArray(key: String): Flow<ByteArray?> {
+    public override fun observeByteArray(key: String, default: ByteArray): Flow<ByteArray> {
         return cache.observeCachedValue<ByteArray>(key).flatMapLatest { cachedValue ->
             when (cachedValue) {
-                null -> delegate.observeByteArray(key)
+                null -> delegate.observeByteArray(key, default)
                 else -> flowOf(cachedValue)
             }
         }
@@ -97,9 +97,9 @@ public class InMemoryFeatureFlagDataStoreOverride(
 }
 
 private inline fun <reified T : Any> StateFlow<Map<String, Any>>.getCachedValue(key: String): T? {
-    return value[key] as? T
+    return value[key] as T?
 }
 
 private inline fun <reified T : Any> StateFlow<Map<String, Any>>.observeCachedValue(key: String): Flow<T?> {
-    return map { map -> map[key] as? T }.distinctUntilChanged()
+    return map { map -> map[key] as T? }.distinctUntilChanged()
 }

--- a/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/MixinFeatureFlagManager.kt
+++ b/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/MixinFeatureFlagManager.kt
@@ -18,26 +18,11 @@ public class MixinFeatureFlagManager(
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T : Any> currentValueOf(flag: FeatureFlag<T>): T = when (flag) {
-        is BooleanFeatureFlag -> {
-            val value = store.getBoolean(flag.key)
-            (value ?: flag.default) as T
-        }
-        is StringFeatureFlag -> {
-            val value = store.getString(flag.key)
-            (value ?: flag.default) as T
-        }
-        is DoubleFeatureFlag -> {
-            val value = store.getDouble(flag.key)
-            (value ?: flag.default) as T
-        }
-        is LongFeatureFlag -> {
-            val value = store.getLong(flag.key)
-            (value ?: flag.default) as T
-        }
-        is ByteArrayFeatureFlag -> {
-            val value = store.getByteArray(flag.key)
-            (value ?: flag.default) as T
-        }
+        is BooleanFeatureFlag -> store.getBoolean(flag.key, flag.default) as T
+        is StringFeatureFlag -> store.getString(flag.key, flag.default) as T
+        is DoubleFeatureFlag -> store.getDouble(flag.key, flag.default) as T
+        is LongFeatureFlag -> store.getLong(flag.key, flag.default) as T
+        is ByteArrayFeatureFlag -> store.getByteArray(flag.key, flag.default) as T
         else -> mixins.firstNotNullOfOrNull { delegate ->
             delegate.currentValueOfOrNull(flag, store)
         } ?: throw IllegalArgumentException("$flag is not a recognized feature flag.")

--- a/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/ObservableFeatureFlagDataStore.kt
+++ b/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/ObservableFeatureFlagDataStore.kt
@@ -3,34 +3,42 @@ package io.github.kevincianfarini.monarch
 import kotlinx.coroutines.flow.Flow
 
 /**
- * A generic definition of a raw feature flag datastore that supports observability
- *
- * NOTE: this uses callbacks vs Flows to maintain compatibility with Swift
+ * A generic definition of a raw feature flag datastore that supports observability.
  */
 public interface ObservableFeatureFlagDataStore : FeatureFlagDataStore {
 
     /**
-     * Observe the [String] value associated with [key] if present. Otherwise, emits null.
+     * Return a [Flow] which emits updates to a [String] value associated with [key] if present. When no value is
+     * present for [key], the returned flow will emit [default]. The returned flow initially emits the value at the
+     * time of collection, and will emit again on each subsequent update for [key].
      */
-    public fun observeString(key: String): Flow<String?>
+    public fun observeString(key: String, default: String): Flow<String>
 
     /**
-     * Observe the [Boolean] value associated with [key] if present. Otherwise, emits null.
+     * Return a [Flow] which emits updates to a [Boolean] value associated with [key] if present. When no value is
+     * present for [key], the returned flow will emit [default]. The returned flow initially emits the value at the
+     * time of collection, and will emit again on each subsequent update for [key].
      */
-    public fun observeBoolean(key: String): Flow<Boolean?>
+    public fun observeBoolean(key: String, default: Boolean): Flow<Boolean>
 
     /**
-     * Observe the [Double] value associated with [key] if present. Otherwise, emits null.
+     * Return a [Flow] which emits updates to a [Double] value associated with [key] if present. When no value is
+     * present for [key], the returned flow will emit [default]. The returned flow initially emits the value at the
+     * time of collection, and will emit again on each subsequent update for [key].
      */
-    public fun observeDouble(key: String): Flow<Double?>
+    public fun observeDouble(key: String, default: Double): Flow<Double>
 
     /**
-     * Observe the [Long] value associated with [key] if present. Otherwise, emits null.
+     * Return a [Flow] which emits updates to a [Long] value associated with [key] if present. When no value is
+     * present for [key], the returned flow will emit [default]. The returned flow initially emits the value at the
+     * time of collection, and will emit again on each subsequent update for [key].
      */
-    public fun observeLong(key: String): Flow<Long?>
+    public fun observeLong(key: String, default: Long): Flow<Long>
 
     /**
-     * Observe the [ByteArray] value associated with [key] if present. Otherwise, emits null.
+     * Return a [Flow] which emits updates to a [ByteArray] value associated with [key] if present. When no value is
+     * present for [key], the returned flow will emit [default]. The returned flow initially emits the value at the
+     * time of collection, and will emit again on each subsequent update for [key].
      */
-    public fun observeByteArray(key: String): Flow<ByteArray?>
+    public fun observeByteArray(key: String, default: ByteArray): Flow<ByteArray>
 }

--- a/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/ObservableMixinFeatureFlagManager.kt
+++ b/core/src/commonMain/kotlin/io/github/kevincianfarini/monarch/ObservableMixinFeatureFlagManager.kt
@@ -21,21 +21,11 @@ public class ObservableMixinFeatureFlagManager(
 
     @Suppress("UNCHECKED_CAST")
     public override fun <T : Any> valuesOf(flag: FeatureFlag<T>): Flow<T> = when (flag) {
-        is BooleanFeatureFlag -> store.observeBoolean(flag.key).map { value ->
-            (value ?: flag.default) as T
-        }
-        is StringFeatureFlag -> store.observeString(flag.key).map { value ->
-            (value ?: flag.default) as T
-        }
-        is DoubleFeatureFlag -> store.observeDouble(flag.key).map { value ->
-            (value ?: flag.default) as T
-        }
-        is LongFeatureFlag -> store.observeLong(flag.key).map { value ->
-            (value ?: flag.default) as T
-        }
-        is ByteArrayFeatureFlag -> store.observeByteArray(flag.key).map { value ->
-            (value ?: flag.default) as T
-        }
+        is BooleanFeatureFlag -> store.observeBoolean(flag.key, flag.default) as Flow<T>
+        is StringFeatureFlag -> store.observeString(flag.key, flag.default) as Flow<T>
+        is DoubleFeatureFlag -> store.observeDouble(flag.key, flag.default) as Flow<T>
+        is LongFeatureFlag -> store.observeLong(flag.key, flag.default) as Flow<T>
+        is ByteArrayFeatureFlag -> store.observeByteArray(flag.key, flag.default) as Flow<T>
         else -> mixins.firstNotNullOfOrNull { delegate ->
             delegate.valuesOfOrNull(flag, store)
         } ?: throw IllegalArgumentException("$flag is not a recognized feature flag.")

--- a/core/src/commonTest/kotlin/io/github/kevincianfarini/monarch/InMemoryFeatureFlagDataStoreOverrideTest.kt
+++ b/core/src/commonTest/kotlin/io/github/kevincianfarini/monarch/InMemoryFeatureFlagDataStoreOverrideTest.kt
@@ -13,11 +13,11 @@ class InMemoryFeatureFlagDataStoreOverrideTest {
 
     @Test fun store_cache_overrides_delegate_synchronous() {
         listOf<Triple<Any, Any, InMemoryFeatureFlagDataStoreOverride.(String) -> Any?>>(
-            Triple(true, false) { getBoolean(it) },
-            Triple("correct", "incorrect") { getString(it) },
-            Triple(1.5, 3.0) { getDouble(it) },
-            Triple(1L, 2L) { getLong(it) },
-            Triple(byteArrayOf(0b1), byteArrayOf(0b0)) { getByteArray(it) }
+            Triple(true, false) { getBoolean(it, false) },
+            Triple("correct", "incorrect") { getString(it, "incorrect") },
+            Triple(1.5, 3.0) { getDouble(it, 3.0) },
+            Triple(1L, 2L) { getLong(it, 2L) },
+            Triple(byteArrayOf(0b1), byteArrayOf(0b0)) { getByteArray(it, byteArrayOf(0b0)) }
         ).forEach { (overrideValue, delegateValue, produceFn) ->
             testCacheOverridesDelegateSynchronousParameterized(overrideValue, delegateValue, produceFn)
         }
@@ -43,11 +43,11 @@ class InMemoryFeatureFlagDataStoreOverrideTest {
 
     @Test fun store_cache_falls_back_to_delegate_synchronous() {
         listOf<Pair<Any, InMemoryFeatureFlagDataStoreOverride.(String) -> Any?>>(
-            Pair(false) { getBoolean(it) },
-            Pair("correct") { getString(it) },
-            Pair(3.0) { getDouble(it) },
-            Pair(2L) { getLong(it) },
-            Pair(byteArrayOf(0b0)) { getByteArray(it) }
+            Pair(false) { getBoolean(it, true) },
+            Pair("correct") { getString(it, "incorrect") },
+            Pair(3.0) { getDouble(it, 1.5) },
+            Pair(2L) { getLong(it, 1L) },
+            Pair(byteArrayOf(0b0)) { getByteArray(it, byteArrayOf(0b1)) }
         ).forEach { (delegateValue, produceFn) ->
             testCacheFallsBackToDelegateSynchronousParameterized(delegateValue, produceFn)
         }
@@ -69,11 +69,11 @@ class InMemoryFeatureFlagDataStoreOverrideTest {
 
     @Test fun store_cache_overrides_delegate_flow() {
         listOf<Triple<Any, Any, InMemoryFeatureFlagDataStoreOverride.(String) -> Flow<*>>>(
-            Triple(true, false) { observeBoolean(it) },
-            Triple("correct", "incorrect") { observeString(it) },
-            Triple(1.5, 3.0) { observeDouble(it) },
-            Triple(1L, 2L) { observeLong(it) },
-            Triple(byteArrayOf(0b1), byteArrayOf(0b0)) { observeByteArray(it) }
+            Triple(true, false) { observeBoolean(it, false) },
+            Triple("correct", "incorrect") { observeString(it, "incorrect") },
+            Triple(1.5, 3.0) { observeDouble(it, 3.0) },
+            Triple(1L, 2L) { observeLong(it, 2L) },
+            Triple(byteArrayOf(0b1), byteArrayOf(0b0)) { observeByteArray(it, byteArrayOf(0b0)) }
         ).forEach { (overrideValue, delegateValue, produceFn) ->
             storeCacheOverridesDelegateFlowParameterized(overrideValue, delegateValue, produceFn)
         }
@@ -101,11 +101,11 @@ class InMemoryFeatureFlagDataStoreOverrideTest {
 
     @Test fun store_cache_falls_back_to_delegate_flow() {
         listOf<Pair<Any, InMemoryFeatureFlagDataStoreOverride.(String) -> Flow<*>>>(
-            Pair(false) { observeBoolean(it) },
-            Pair("correct") { observeString(it) },
-            Pair(3.0) { observeDouble(it) },
-            Pair(2L) { observeLong(it) },
-            Pair(byteArrayOf(0b0)) { observeByteArray(it) }
+            Pair(false) { observeBoolean(it, true) },
+            Pair("correct") { observeString(it, "incorrect") },
+            Pair(3.0) { observeDouble(it, 1.5) },
+            Pair(2L) { observeLong(it, 1L) },
+            Pair(byteArrayOf(0b0)) { observeByteArray(it, byteArrayOf(0b1)) }
         ).forEach { (delegateValue, produceFn) ->
             storeCacheFallsBackToDelegateFlowParameterized(delegateValue, produceFn)
         }
@@ -129,11 +129,11 @@ class InMemoryFeatureFlagDataStoreOverrideTest {
 
     @Test fun writing_to_store_cache_emits_new_value_in_active_flows() {
         listOf<Triple<Any, InMemoryFeatureFlagDataStoreOverride.(String) -> Unit, InMemoryFeatureFlagDataStoreOverride.(String) -> Flow<*>>>(
-            Triple(true, { setBoolean(it, false) }) { observeBoolean(it) },
-            Triple("correct", { setString(it, "also correct") }) { observeString(it) },
-            Triple(1.5, { setDouble(it, 3.0) }) { observeDouble(it) },
-            Triple(1L, { setLong(it, 3L) }) { observeLong(it) },
-            Triple(byteArrayOf(0b1), { setByteArray(it, byteArrayOf(0b0)) }) { observeByteArray(it) }
+            Triple(true, { setBoolean(it, false) }) { observeBoolean(it, true) },
+            Triple("correct", { setString(it, "also correct") }) { observeString(it, "incorrect") },
+            Triple(1.5, { setDouble(it, 3.0) }) { observeDouble(it, 4.5) },
+            Triple(1L, { setLong(it, 3L) }) { observeLong(it, 2L) },
+            Triple(byteArrayOf(0b1), { setByteArray(it, byteArrayOf(0b0)) }) { observeByteArray(it, byteArrayOf(0b101)) }
         ).forEach { (initialValue, newValue, produceFn) ->
             writingToStoreCacheEmitsNewValueParameterized(initialValue, newValue, produceFn)
         }

--- a/core/src/commonTest/kotlin/io/github/kevincianfarini/monarch/flags.kt
+++ b/core/src/commonTest/kotlin/io/github/kevincianfarini/monarch/flags.kt
@@ -22,9 +22,9 @@ object ObservableIntDecodingMixin : ObservableFeatureFlagManagerMixin {
         flag: FeatureFlag<T>,
         store: ObservableFeatureFlagDataStore,
     ): Flow<T>? = when (flag) {
-        is IntFeatureFlag -> store.observeString(flag.key).map { str ->
-            (str?.toInt() ?: flag.default) as T
-        }
+        is IntFeatureFlag -> store.observeString(flag.key, flag.default.toString()).map { str ->
+            str.toInt()
+        } as Flow<T>
         else -> null
     }
 
@@ -32,9 +32,7 @@ object ObservableIntDecodingMixin : ObservableFeatureFlagManagerMixin {
         flag: FeatureFlag<T>,
         store: FeatureFlagDataStore
     ): T? = when (flag) {
-        is IntFeatureFlag -> {
-            (store.getString(flag.key)?.toInt() ?: flag.default) as T?
-        }
+        is IntFeatureFlag -> store.getString(flag.key, flag.default.toString()).toInt() as T
         else -> null
     }
 }

--- a/mixins/kotlinx-serialization-json/src/commonMain/kotlin/io/github/kevincianfarini/monarch/mixins/JsonFeatureFlag.kt
+++ b/mixins/kotlinx-serialization-json/src/commonMain/kotlin/io/github/kevincianfarini/monarch/mixins/JsonFeatureFlag.kt
@@ -1,16 +1,20 @@
 package io.github.kevincianfarini.monarch.mixins
 
 import io.github.kevincianfarini.monarch.FeatureFlag
-import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 
 public abstract class JsonFeatureFlag<OptionType : Any>(
     public override val key: String,
     public override val default: OptionType,
-    private val deserializer: DeserializationStrategy<OptionType>,
+    private val serializer: KSerializer<OptionType>,
 ) : FeatureFlag<OptionType> {
 
     internal fun deserialize(raw: String, json: Json): OptionType {
-        return json.decodeFromString(deserializer, raw)
+        return json.decodeFromString(serializer, raw)
+    }
+
+    internal fun serializedDefault(json: Json): String {
+        return json.encodeToString(serializer, default)
     }
 }

--- a/mixins/kotlinx-serialization-json/src/commonMain/kotlin/io/github/kevincianfarini/monarch/mixins/JsonFeatureFlagManagerMixin.kt
+++ b/mixins/kotlinx-serialization-json/src/commonMain/kotlin/io/github/kevincianfarini/monarch/mixins/JsonFeatureFlagManagerMixin.kt
@@ -13,9 +13,8 @@ public class JsonFeatureFlagManagerMixin(
         flag: FeatureFlag<T>,
         store: FeatureFlagDataStore,
     ): T? = when (flag) {
-        is JsonFeatureFlag<T> -> {
-            val value = store.getString(flag.key)?.let { flag.deserialize(it, json) }
-            (value ?: flag.default)
+        is JsonFeatureFlag<T> -> store.getString(flag.key, flag.serializedDefault(json)).let { string ->
+            flag.deserialize(string, json)
         }
         else -> null
     }

--- a/mixins/kotlinx-serialization-json/src/commonMain/kotlin/io/github/kevincianfarini/monarch/mixins/ObservableJsonFeatureFlagManagerMixin.kt
+++ b/mixins/kotlinx-serialization-json/src/commonMain/kotlin/io/github/kevincianfarini/monarch/mixins/ObservableJsonFeatureFlagManagerMixin.kt
@@ -1,5 +1,6 @@
 package io.github.kevincianfarini.monarch.mixins
 
+import io.github.kevincianfarini.monarch.FeatureFlag
 import io.github.kevincianfarini.monarch.FeatureFlagManagerMixin
 import io.github.kevincianfarini.monarch.ObservableFeatureFlagDataStore
 import io.github.kevincianfarini.monarch.ObservableFeatureFlagManagerMixin
@@ -12,11 +13,11 @@ public class ObservableJsonFeatureFlagManagerMixin(
 ) : ObservableFeatureFlagManagerMixin, FeatureFlagManagerMixin by JsonFeatureFlagManagerMixin(json) {
 
     public override fun <T : Any> valuesOfOrNull(
-        flag: io.github.kevincianfarini.monarch.FeatureFlag<T>,
+        flag: FeatureFlag<T>,
         store: ObservableFeatureFlagDataStore
     ): Flow<T>? = when (flag) {
-        is JsonFeatureFlag<T> -> store.observeString(flag.key).map { string ->
-            string?.let { flag.deserialize(it, json) } ?: flag.default
+        is JsonFeatureFlag<T> -> store.observeString(flag.key, flag.serializedDefault(json)).map { string ->
+            flag.deserialize(string, json)
         }
         else -> null
     }

--- a/mixins/kotlinx-serialization-json/src/commonTest/kotlin/io/github/kevincianfarini/monarch/mixins/JsonFeatureFlagTest.kt
+++ b/mixins/kotlinx-serialization-json/src/commonTest/kotlin/io/github/kevincianfarini/monarch/mixins/JsonFeatureFlagTest.kt
@@ -19,9 +19,8 @@ class JsonFeatureFlagTest {
 object SomeJsonFlag : JsonFeatureFlag<Foo>(
     key = "some_flag",
     default = Foo(1),
-    deserializer = Foo.serializer(),
+    serializer = Foo.serializer(),
 )
 
-@Serializable data class Foo(
-    val bar: Int,
-)
+@Serializable
+data class Foo(val bar: Int)

--- a/test/src/commonMain/kotlin/io/github/kevincianfarini/monarch/InMemoryFeatureFlagDataStore.kt
+++ b/test/src/commonMain/kotlin/io/github/kevincianfarini/monarch/InMemoryFeatureFlagDataStore.kt
@@ -1,52 +1,49 @@
 package io.github.kevincianfarini.monarch
 
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.*
 
 public class InMemoryFeatureFlagDataStore : ObservableFeatureFlagDataStore {
 
     private val store = MutableStateFlow<Map<String, Any?>>(emptyMap())
 
-    public override fun observeString(key: String): Flow<String?> {
-        return getValues(key).map { it as String? }
+    public override fun observeString(key: String, default: String): Flow<String> {
+        return store.observeValue(key, default)
     }
 
-    public override fun observeBoolean(key: String): Flow<Boolean?> {
-        return getValues(key).map { it as Boolean? }
+    public override fun observeBoolean(key: String, default: Boolean): Flow<Boolean> {
+        return store.observeValue(key, default)
     }
 
-    public override fun observeDouble(key: String): Flow<Double?> {
-        return getValues(key).map { it as Double? }
+    public override fun observeDouble(key: String, default: Double): Flow<Double> {
+        return store.observeValue(key, default)
     }
 
-    public override fun observeLong(key: String): Flow<Long?> {
-        return getValues(key).map { it as Long? }
+    public override fun observeLong(key: String, default: Long): Flow<Long> {
+        return store.observeValue(key, default)
     }
 
-    public override fun observeByteArray(key: String): Flow<ByteArray?> {
-        return getValues(key).map { it as ByteArray? }
+    public override fun observeByteArray(key: String, default: ByteArray): Flow<ByteArray> {
+        return store.observeValue(key, default)
     }
 
-    public override fun getBoolean(key: String): Boolean? {
-        return getValue(key) as Boolean?
+    public override fun getBoolean(key: String, default: Boolean): Boolean {
+        return store.getValue(key, default)
     }
 
-    public override fun getString(key: String): String? {
-        return getValue(key) as String?
+    public override fun getString(key: String, default: String): String {
+        return store.getValue(key, default)
     }
 
-    public override fun getDouble(key: String): Double? {
-        return getValue(key) as Double?
+    public override fun getDouble(key: String, default: Double): Double {
+        return store.getValue(key, default)
     }
 
-    public override fun getLong(key: String): Long? {
-        return getValue(key) as Long?
+    public override fun getLong(key: String, default: Long): Long {
+        return store.getValue(key, default)
     }
 
-    public override fun getByteArray(key: String): ByteArray? {
-        return getValue(key) as ByteArray?
+    public override fun getByteArray(key: String, default: ByteArray): ByteArray {
+        return store.getValue(key, default)
     }
 
     public fun setValue(key: String, value: Any?) {
@@ -54,10 +51,12 @@ public class InMemoryFeatureFlagDataStore : ObservableFeatureFlagDataStore {
             map.plus(key to value)
         }
     }
+}
 
-    private fun getValues(key: String): Flow<Any?> {
-        return store.map { map -> map[key] }
-    }
+private inline fun <reified T> StateFlow<Map<String, Any?>>.getValue(key: String, default: T): T {
+    return (value[key] as T?) ?: default
+}
 
-    private fun getValue(key: String): Any? = store.value[key]
+private inline fun <reified T> StateFlow<Map<String, Any?>>.observeValue(key: String, default: T): Flow<T> {
+    return map { map -> (map[key] as T?) ?: default }.distinctUntilChanged()
 }


### PR DESCRIPTION
Prior to this commit the functions within `FeatureFlagDataStore` and
`ObservableFeatureFlagDataStore` did not take default parameters.
Instead, this was handled one level up in the `FeatureFlagManager` and
`ObservableFeatureFlagManager` implementations. This option was good for
simplicity, but presented one problem.

The LaunchDarkly SDK requires that customers of their API set certain
configurations in order to reliably use their client APIs which return
an `EvaluationDetail<T>`. Prior to this commit we used the evaluation of
flags to determine if the static default value we passed into the LD
client API was returned to us. This gave us to signal we needed to then
return the `FeatureFlag#default` value that this library guarantees API
consumers will have returned when no value is available.

It's unreasonable for us to expect all of our API consumers who use LD
would properly configure their client for our implementation needs.
Rather than enforcing that requirement, this commit alters the API
surface of our data stores such that they have knowledge of what the
`FeatureFlag#default` value is. Instead of having the feature flag
managers responsible for returning defaults directly from flags, they
now query defaults and pass them along to a data store. This gives
implementations the flexibility to pass the default value along to the
underlying SDK in use, or use some other method for determining if a
default value needs to be returned.

References #4
