### PR TITLE
Introduce wasmJs target

### DIFF
--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
 plugins {
     alias(libs.plugins.dokka)
     alias(libs.plugins.kotlin.compose)
@@ -13,6 +15,19 @@ kotlin {
     iosSimulatorArm64()
     iosX64()
     jvm()
+    js {
+        nodejs {
+            testTask {
+                useMocha {
+                    timeout = "5s"
+                }
+            }
+        }
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        nodejs()
+    }
     linuxArm64()
     linuxX64()
     macosArm64()

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
 plugins {
     alias(libs.plugins.dokka)
     alias(libs.plugins.kotlin.multiplatform)
@@ -20,6 +22,10 @@ kotlin {
                 }
             }
         }
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        nodejs()
     }
     linuxArm64()
     linuxX64()

--- a/integrations/environment-variable/build.gradle.kts
+++ b/integrations/environment-variable/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
 plugins {
     alias(libs.plugins.dokka)
     alias(libs.plugins.kotlin.multiplatform)
@@ -20,6 +22,10 @@ kotlin {
                 }
             }
         }
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        nodejs()
     }
     linuxArm64()
     linuxX64()

--- a/integrations/environment-variable/src/wasmJsMain/kotlin/io/github/kevincianfarini/monarch/environment/environment.kt
+++ b/integrations/environment-variable/src/wasmJsMain/kotlin/io/github/kevincianfarini/monarch/environment/environment.kt
@@ -1,0 +1,3 @@
+package io.github.kevincianfarini.monarch.environment
+
+internal actual fun getSystemEnvVar(key: String): String? = null

--- a/mixins/kotlinx-serialization-json/build.gradle.kts
+++ b/mixins/kotlinx-serialization-json/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
 plugins {
     alias(libs.plugins.dokka)
     alias(libs.plugins.kotlin.multiplatform)
@@ -20,6 +22,10 @@ kotlin {
                 }
             }
         }
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        nodejs()
     }
     linuxArm64()
     linuxX64()

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+
 plugins {
     alias(libs.plugins.dokka)
     alias(libs.plugins.kotlin.multiplatform)
@@ -20,6 +22,10 @@ kotlin {
                 }
             }
         }
+    }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        nodejs()
     }
     linuxArm64()
     linuxX64()


### PR DESCRIPTION
Simply adds the wasmJs target, environment variables support for this platform isn't configured in this PR due to the nature of the wasmJs target.

Raising as a draft currently as I have not been able to confirm this is working as intended - having some issues currently running locally! Might need some pointers 👀 